### PR TITLE
feat(public): add keybase proof and update redirects for .well-known

### DIFF
--- a/public/.well-known/keybase.txt
+++ b/public/.well-known/keybase.txt
@@ -1,0 +1,53 @@
+https://keybase.io/ncaq
+--------------------------------------------------------------------
+
+I hereby claim:
+
+  * I am an admin of https://ncaq.net
+  * I am ncaq (https://keybase.io/ncaq) on keybase.
+  * I have a public key ASCsmQ3khGkf2BIDprBc92-WDIvebtgSRTKcpnCbN_1_two
+
+To do so, I am signing this object:
+
+{
+  "body": {
+    "key": {
+      "eldest_kid": "0120ac990de484691fd81203a6b05cf76f960c8bde6ed81245329ca6709b37fd7fb70a",
+      "host": "keybase.io",
+      "kid": "0120ac990de484691fd81203a6b05cf76f960c8bde6ed81245329ca6709b37fd7fb70a",
+      "uid": "55cf739cf652ea2af20e13c750e4dd19",
+      "username": "ncaq"
+    },
+    "merkle_root": {
+      "ctime": 1768018812,
+      "hash": "c9cc42a26bf0bfb5f792cc973f0a00abcef901ffa1d43039c0415139a7b53e959ec6986290aa482e43ba0100689ac21bfe5d009f9c114d28b36e1ae80f2ef145",
+      "hash_meta": "7a25405abcec558694ebb5664ae9b99a29cb575ffa3c2a1356ad660402a97cab",
+      "seqno": 27337696
+    },
+    "service": {
+      "entropy": "HXyQ5cja8zPoLfy7rr4eTUae",
+      "hostname": "ncaq.net",
+      "protocol": "https:"
+    },
+    "type": "web_service_binding",
+    "version": 2
+  },
+  "client": {
+    "name": "keybase.io go client",
+    "version": "6.5.1"
+  },
+  "ctime": 1768018878,
+  "expire_in": 504576000,
+  "prev": "18626fc8bd69d6b5dc7e687cb41086c46dd63947abe9be9b50c61eb28739f445",
+  "seqno": 9,
+  "tag": "signature"
+}
+
+which yields the signature:
+
+hKRib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEgrJkN5IRpH9gSA6awXPdvlgyL3m7YEkUynKZwmzf9f7cKp3BheWxvYWTESpcCCcQgGGJvyL1p1rXcfmh8tBCGxG3WOUer6b6bUMYesoc59EXEIBkdDm6C+0FCYTTO2eBho7SFRUakDXpVqkRetmgAruDvAgHCo3NpZ8RA2CENpHuQ6RPr9iK0vp9kpshvwX17677HC6qIXoBX62kwGzpcoBWX23p6dDttez3T+66Fj03EZKUWvjI4/FsZDahzaWdfdHlwZSCkaGFzaIKkdHlwZQildmFsdWXEIGz65BhaLAuOHcseZCe1xEKu8Qp73s0kA4HuLXXzpVX6o3RhZ80CAqd2ZXJzaW9uAQ==
+
+And finally, I am proving ownership of this host by posting or
+appending to this document.
+
+View my publicly-auditable identity here: https://keybase.io/ncaq

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,2 @@
+/.well-known/* /.well-known/:splat 200
 /* https://www.ncaq.net/:splat 301


### PR DESCRIPTION
- Add keybase.txt to prove domain ownership for keybase.io
- Update _redirects to support .well-known paths with 200 status
