### PR TITLE
fix(flake): publicディレクトリのコピー時に隠しファイルも含めるよう修正

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
         {
           packages.default = pkgs.runCommand "ncaq-net" { nativeBuildInputs = [ pkgs.gnupg ]; } ''
             mkdir -p $out
-            cp -r ${./public}/* $out/
+            cp -r --no-preserve=mode ${./public}/. $out/
 
             export GNUPGHOME=$(mktemp -d)
             gpg --import ${inputs.dotfiles}/key/ncaq-public-key.asc


### PR DESCRIPTION
普段zshの拡張を使っているので含まれないのを見落としていました。
